### PR TITLE
light の地図スタイルを変更

### DIFF
--- a/public/styles/light.json
+++ b/public/styles/light.json
@@ -1853,14 +1853,14 @@
       "filter": ["all", [">=", "admin_level", 4], ["<=", "admin_level", 8], ["!=", "maritime", 1]],
       "layout": { "line-join": "round" },
       "paint": {
-        "line-color": "#9e9cab",
+        "line-color": "hsl(0, 0%, 70%)",
         "line-dasharray": [3, 1, 1, 1],
         "line-width": {
           "base": 1.4,
           "stops": [
             [4, 0.4],
             [5, 1],
-            [12, 3]
+            [12, 2]
           ]
         }
       }

--- a/public/styles/light.json
+++ b/public/styles/light.json
@@ -344,7 +344,7 @@
       "source": "openmaptiles",
       "source-layer": "water",
       "filter": ["all"],
-      "layout": { "visibility": "visible" },
+      "layout": { "visibility": "none" },
       "paint": { "fill-pattern": "wave", "fill-translate": [0, 2.5] }
     },
     {

--- a/public/styles/light.json
+++ b/public/styles/light.json
@@ -737,7 +737,7 @@
       "source": "openmaptiles",
       "source-layer": "transportation",
       "filter": ["all", ["in", "class", "ferry"]],
-      "layout": { "line-join": "round", "visibility": "visible" },
+      "layout": { "line-join": "round", "visibility": "none" },
       "paint": {
         "line-color": "rgba(108, 159, 182, 1)",
         "line-dasharray": [2, 2],

--- a/public/styles/light.json
+++ b/public/styles/light.json
@@ -1912,7 +1912,7 @@
       "source": "openmaptiles",
       "source-layer": "boundary",
       "filter": ["all", ["in", "admin_level", 2, 4], ["==", "maritime", 1]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "layout": { "line-cap": "round", "line-join": "round", "visibility": "none" },
       "paint": {
         "line-color": "rgba(154, 189, 214, 1)",
         "line-opacity": {

--- a/public/styles/light.json
+++ b/public/styles/light.json
@@ -1851,7 +1851,7 @@
       "source": "openmaptiles",
       "source-layer": "boundary",
       "filter": ["all", [">=", "admin_level", 4], ["<=", "admin_level", 8], ["!=", "maritime", 1]],
-      "layout": { "line-join": "round" },
+      "layout": { "line-join": "round", "visibility": "none" },
       "paint": {
         "line-color": "hsl(0, 0%, 70%)",
         "line-dasharray": [3, 1, 1, 1],


### PR DESCRIPTION
地図を見やすくするため、不要だと思われる要素を非表示にするなどの変更を行った。主に以下のものが対象。

- 水面パターン
- 自治体などの境界線

| 変更前 | 変更後 |
|--------|--------|
| <img width="2308" height="1870" alt="localhost_5173_ (1)" src="https://github.com/user-attachments/assets/3fbd968a-80d7-4fa9-b215-30d83883c540" /> | <img width="2308" height="1870" alt="localhost_5173_" src="https://github.com/user-attachments/assets/139ad04a-f740-4e09-9704-b55677547fb3" /> | 