### PR TITLE
chore: GitHub Pagesで正しくパスを指定するための設定を追加

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,6 @@ import react from "@vitejs/plugin-react";
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: "/map-style",
   plugins: [react()],
 });


### PR DESCRIPTION
GitHub Pages でデプロイするアクションを追加しただけでは以下のようなエラーが出たため、Vite の設定を追加する。

<img width="990" height="45" alt="image" src="https://github.com/user-attachments/assets/3fc6492a-7a63-4818-92fe-ea4646347a4e" />
