### PR TITLE
feat: スプライトへ POI を一通り追加

### DIFF
--- a/sprite-svg/dark.svg
+++ b/sprite-svg/dark.svg
@@ -754,6 +754,10 @@
     <g transform="translate(80 220)">
       <path d="M 10 4 L 4 15 L 16 15 z" class="fill-and-stroke" stroke-width="1.5" />
     </g>
+    <view id="triangle_11" viewBox="100 220 20 20" />
+    <g transform="translate(100 220)">
+      <path d="M 10 4 L 4 15 L 16 15 z" class="stroke-only" stroke-width="1.5" />
+    </g>
     <!-- <g fill="none" stroke="red" stroke-width="0.2">
       <path
         d="M 0 0 h 400 M 0 20 h 400 M 0 40 h 400 M 0 60 h 400 M 0 80 h 400 M 0 100 h 400 M 0 120 h 400 M 0 140 h 400 M 0 160 h 400 M 0 180 h 400 M 0 200 h 400 M 0 220 h 400 M 0 240 h 400 M 0 260 h 400" />


### PR DESCRIPTION
スプライトで POI として表示するモノを一通り追加する。

<img width="395" height="598" alt="image" src="https://github.com/user-attachments/assets/edd8ceb2-8d5f-4a92-8f24-f8cbfdadafc6" />

### 今後やること

- 道路番号等の追加
- スプライト SVG のリファクタリング
  - 表記揺れの統一
  - スタイル指定の簡素化

