### PR TITLE
refactor: Dark のスプライトの SVG をリファクタリング

### DIFF
--- a/sprite-svg/dark.svg
+++ b/sprite-svg/dark.svg
@@ -20,6 +20,38 @@
       stroke-linejoin: round;
       stroke-linecap: round;
     }
+
+    .w05 {
+      stroke-width: 0.5;
+    }
+
+    .w07 {
+      stroke-width: 0.7;
+    }
+
+    .w10 {
+      stroke-width: 1;
+    }
+
+    .w12 {
+      stroke-width: 1.2;
+    }
+
+    .w14 {
+      stroke-width: 1.4;
+    }
+
+    .w15 {
+      stroke-width: 1.5;
+    }
+
+    .w18 {
+      stroke-width: 1.8;
+    }
+
+    .w20 {
+      stroke-width: 2.0;
+    }
   </style>
   <g>
     <!-- 交通系 1行目 -->
@@ -52,8 +84,8 @@
       <rect x="4" y="2" width="12" height="13" rx="1.5" class="f" mask="url(#railway_11_mask)" />
       <path d="M 7 15.5 l -3 3 l 1 0 l 3 -3" class="f" />
       <path d="M 12 15.5 l 3 3 l 1 0 l -3 -3" class="f" />
-      <path d="M 5 16 l 10 0" class="s" stroke-width="0.5" />
-      <path d="M 3.5 17.5 l 13 0" class="s" stroke-width="0.5" />
+      <path d="M 5 16 l 10 0" class="s w05" />
+      <path d="M 3.5 17.5 l 13 0" class="s w05" />
     </g>
     <view id="rail_metro_11" viewBox="40 0 20 20" />
     <g transform="translate(40 0)">
@@ -71,11 +103,11 @@
         </mask>
       </defs>
       <rect x="5" y="3" width="10" height="12" rx="1.5" class="f" mask="url(#rail_metro_11_mask)" />
-      <circle cx="10" cy="10" r="9" class="s" stroke-width="0.7" mask="url(#rail_metro_11_tunnel_mask)" />
+      <circle cx="10" cy="10" r="9" class="s w07" mask="url(#rail_metro_11_tunnel_mask)" />
       <path d="M 7 15.5 l -3 3 l 1 0 l 3 -3" class="f" />
       <path d="M 12 15.5 l 3 3 l 1 0 l -3 -3" class="f" />
-      <path d="M 5 16 l 10 0" class="s" stroke-width="0.5" />
-      <path d="M 3.5 17.5 l 13 0" class="s" stroke-width="0.5" />
+      <path d="M 5 16 l 10 0" class="s w05" />
+      <path d="M 3.5 17.5 l 13 0" class="s w05" />
     </g>
     <view id="rail_light_11" viewBox="60 0 20 20" />
     <g transform="translate(60 0)">
@@ -90,8 +122,8 @@
       <rect x="5" y="2" width="10" height="13" rx="1.5" class="f" mask="url(#rail_light_11_mask)" />
       <path d="M 7 15.5 l -3 3 l 1 0 l 3 -3" class="f" />
       <path d="M 12 15.5 l 3 3 l 1 0 l -3 -3" class="f" />
-      <path d="M 5 16 l 10 0" class="s" stroke-width="0.5" />
-      <path d="M 3.5 17.5 l 13 0" class="s" stroke-width="0.5" />
+      <path d="M 5 16 l 10 0" class="s w05" />
+      <path d="M 3.5 17.5 l 13 0" class="s w05" />
     </g>
     <view id="airport_11" viewBox="80 0 20 20" />
     <g transform="translate(80 0)">
@@ -113,13 +145,13 @@
           <path d="M 13 9 l 3 3 h -3 z" fill="black" stroke="black" stroke-width="1.5" stroke-linejoin="round" />
         </mask>
       </defs>
-      <path d="M 6 8 h 7 l 4 4 v 2 h -6 l -3 -5 h -2 z" class="fs" stroke-width="1.5" mask="url(#heliport_11_mask)" />
-      <path d="M 15 15 v 1.5 z" class="s" stroke-width="1.2" />
-      <path d="M 11 4 v 3 z" class="s" stroke-width="1.2" />
-      <path d="M 6 4 h 10 z" class="s" stroke-width="1.5" />
-      <path d="M 11 15 v 1.5 z" class="s" stroke-width="1.2" />
-      <path d="M 8 16 l 1 1 h 8 l 1 -1" class="s" stroke-width="1.2" />
-      <circle cx="3.5" cy="8.5" r="1.5" class="s" stroke-width="1.2" />
+      <path d="M 6 8 h 7 l 4 4 v 2 h -6 l -3 -5 h -2 z" class="fs w15" mask="url(#heliport_11_mask)" />
+      <path d="M 15 15 v 1.5 z" class="s w12" />
+      <path d="M 11 4 v 3 z" class="s w12" />
+      <path d="M 6 4 h 10 z" class="s w15" />
+      <path d="M 11 15 v 1.5 z" class="s w12" />
+      <path d="M 8 16 l 1 1 h 8 l 1 -1" class="s w12" />
+      <circle cx="3.5" cy="8.5" r="1.5" class="s w12" />
     </g>
     <view id="rocket_11" viewBox="140 0 20 20" />
     <g transform="translate(140 0)">
@@ -137,10 +169,10 @@
     <!-- 交通系 2行目 -->
     <view id="harbor_11" viewBox="0 20 20 20" />
     <g transform="translate(0 20)">
-      <circle cx="10" cy="5" r="2" class="s" stroke-width="1.5" />
-      <path d="M 10 7 v 8 " class="s" stroke-width="1.5" />
-      <path d="M 3 8 q 0 8 7 8 t 7 -8" class="s" stroke-width="1.5" />
-      <path d="M 3 8 q 0 8 7 9 q 7 -1 7 -9" class="s" stroke-width="1.5" />
+      <circle cx="10" cy="5" r="2" class="s w15" />
+      <path d="M 10 7 v 8 " class="s w15" />
+      <path d="M 3 8 q 0 8 7 8 t 7 -8" class="s w15" />
+      <path d="M 3 8 q 0 8 7 9 q 7 -1 7 -9" class="s w15" />
     </g>
     <view id="ferry_terminal_11" viewBox="20 20 20 20" />
     <g transform="translate(20 20)">
@@ -158,25 +190,25 @@
       <rect x="8" y="1.5" width="4" height="1.5" class="f" />
       <rect x="5" y="4" width="10" height="5" class="f" mask="url(#ferry_terminal_11_mask)" />
       <path d="M 3 9 l 7 -2 l 7 2 l -3 6 h -8" class="f" mask="url(#ferry_terminal_11_mask)" />
-      <path d="M 2 17 c 2 0 2 -2 4 -2 s 2 2 4 2 s 2 -2 4 -2 s 2 2 4 2" class="s" stroke-width="1.5" />
+      <path d="M 2 17 c 2 0 2 -2 4 -2 s 2 2 4 2 s 2 -2 4 -2 s 2 2 4 2" class="s w15" />
     </g>
     <view id="entrance_11" viewBox="40 20 20 20" />
     <g transform="translate(40 20)">
       <circle cx="9" cy="4.5" r="1.5" class="f" />
       <path d="M 7.5 11 v -3 a 1.5 1.5 0 0 1 3 0 z" class="f" />
-      <path d="M 4 16 h 3 l 6 -6 h 3 " class="s" stroke-width="2" />
+      <path d="M 4 16 h 3 l 6 -6 h 3 " class="s w20" />
     </g>
     <view id="bicycle_rental_11" viewBox="60 20 20 20" />
     <g transform="translate(60 20)">
       <circle cx="13" cy="3" r="1.5" class="f" />
-      <path d="M 8 12 a 3 3 0 1 0 0 3" class="s" stroke-width="1.2" />
-      <path d="M 12 12 a 3 3 0 1 1 0 3" class="s" stroke-width="1.2" />
-      <path d="M 10 15 v -5 l -2 -2 l 3 -3 l 3 3 h 2" class="s" stroke-width="1.5" />
+      <path d="M 8 12 a 3 3 0 1 0 0 3" class="s w12" />
+      <path d="M 12 12 a 3 3 0 1 1 0 3" class="s w12" />
+      <path d="M 10 15 v -5 l -2 -2 l 3 -3 l 3 3 h 2" class="s w15" />
     </g>
     <view id="information_11" viewBox="80 20 20 20" />
     <g transform="translate(80 20)">
       <circle cx="10" cy="5" r="2" class="f" />
-      <path d="M 7.5 9 h 2 v 8 h -2 h 6 h -2 v -8 z" class="fs" stroke-width="1.5" />
+      <path d="M 7.5 9 h 2 v 8 h -2 h 6 h -2 v -8 z" class="fs w15" />
     </g>
     <!-- 公共系 1行目 -->
     <view id="school_11" viewBox="0 40 20 20" />
@@ -212,7 +244,7 @@
       </defs>
       <rect x="8" y="8" width="8" height="8" rx="4" ry="2" class="f" mask="url(#police_11_mask)" />
       <rect x="8" y="14" width="8" height="4" rx="1" class="f" mask="url(#police_11_mask)" />
-      <path d="M 8 10 l -4 -2 l 3.5 -2" class="s" style="stroke-width:2" />
+      <path d="M 8 10 l -4 -2 l 3.5 -2" class="s w20" />
       <rect x="10" y="4" width="4" height="3.5" class="f" rx="2" />
       <rect x="10" y="4" width="4" height="2" class="f" />
       <path d="M 9.5 2 h 5 l -0.5 0.5 h -4 z" class="fs" />
@@ -241,27 +273,26 @@
     <view id="town_hall_11" viewBox="100 40 20 20" />
     <g transform="translate(100 40)">
       <path d="M 10 3 l -7 2 v 1 h 14 v -1 z" class="f" />
-      <path d="M 5 14 v -6 h 10 v 6" class="s" stroke-width="1.5" />
-      <path d="M 8.333 14 v -6 h 3.333 v 6" class="s" stroke-width="1.5" />
+      <path d="M 5 14 v -6 h 10 v 6" class="s w15" />
+      <path d="M 8.333 14 v -6 h 3.333 v 6" class="s w15" />
       <path d="M 5 14 l -2 1.5 v 1 h 14 v -1 l -2 -1.5 z" class="fs" />
     </g>
     <view id="library_11" viewBox="120 40 20 20" />
     <g transform="translate(120 40)">
-      <path d="M 10 6 q -2 -2 -7 -2 v 10 q 5 0 7 2" class="s" stroke-width="1.5" />
-      <path d="M 10 6 q -2 -2 -7 -2 v 10 q 5 0 7 2" class="s" stroke-width="1.5"
-        transform="translate(20 0) scale(-1 1)" />
-      <path d="M 8 8 q -1 -0.8 -3 -1" class="s" stroke-width="1" />
-      <path d="M 8 10 q -1 -0.8 -3 -1" class="s" stroke-width="1" />
-      <path d="M 8 12 q -1 -0.8 -3 -1" class="s" stroke-width="1" />
-      <path d="M 12 8 q 1 -0.8 3 -1" class="s" stroke-width="1" />
-      <path d="M 12 10 q 1 -0.8 3 -1" class="s" stroke-width="1" />
-      <path d="M 12 12 q 1 -0.8 3 -1" class="s" stroke-width="1" />
+      <path d="M 10 6 q -2 -2 -7 -2 v 10 q 5 0 7 2" class="s w15" />
+      <path d="M 10 6 q -2 -2 -7 -2 v 10 q 5 0 7 2" class="s w15" transform="translate(20 0) scale(-1 1)" />
+      <path d="M 8 8 q -1 -0.8 -3 -1" class="s" />
+      <path d="M 8 10 q -1 -0.8 -3 -1" class="s" />
+      <path d="M 8 12 q -1 -0.8 -3 -1" class="s" />
+      <path d="M 12 8 q 1 -0.8 3 -1" class="s" />
+      <path d="M 12 10 q 1 -0.8 3 -1" class="s" />
+      <path d="M 12 12 q 1 -0.8 3 -1" class="s" />
     </g>
     <view id="embassy_11" viewBox="140 40 20 20" />
     <g transform="translate(140 40)">
       <circle cx="4" cy="4" r="1.8" class="f" />
-      <path d="M 4 8 v 10" class="s" stroke-width="1.5" />
-      <path d="M 7.5 6 q 2 -3 5 -1 q 2 2 5 -1 v 6 q -3 3 -5 1 q -3 -2 -5 1 z" class="fs" stroke-width="1.5" />
+      <path d="M 4 8 v 10" class="s w15" />
+      <path d="M 7.5 6 q 2 -3 5 -1 q 2 2 5 -1 v 6 q -3 3 -5 1 q -3 -2 -5 1 z" class="fs w15" />
     </g>
     <!-- 公共系 2行目 -->
     <view id="hospital_11" viewBox="0 60 20 20" />
@@ -277,9 +308,9 @@
     </g>
     <view id="doctor_11" viewBox="40 60 20 20" />
     <g transform="translate(40 60)">
-      <path d="M 5 3 h -2 v 4 a 4 4 0 0 0 8 0 v -4 h -2 " class="s" stroke-width="1.5" />
-      <path d="M 7 11 v 2 a 4 4 0 0 0 9 0 v -4" class="s" stroke-width="1.5" />
-      <circle cx="16" cy="7" r="2" class="s" stroke-width="1.5" />
+      <path d="M 5 3 h -2 v 4 a 4 4 0 0 0 8 0 v -4 h -2 " class="s w15" />
+      <path d="M 7 11 v 2 a 4 4 0 0 0 9 0 v -4" class="s w15" />
+      <circle cx="16" cy="7" r="2" class="s w15" />
     </g>
     <view id="pharmacy_11" viewBox="60 60 20 20" />
     <g transform="translate(60 60)">
@@ -290,7 +321,7 @@
           <path d="M 6 11 a 2 2 0 0 0 4 4 l 2 -2 l -4 -4 z" class="f" style="fill:black" />
         </mask>
       </defs>
-      <path d="M 10 3 l -7 4 v 10 h 14 v -10 z" class="fs" stroke-width="2" mask="url(#pharmacy_11_mask)" />
+      <path d="M 10 3 l -7 4 v 10 h 14 v -10 z" class="fs w20" mask="url(#pharmacy_11_mask)" />
     </g>
     <view id="toilet_11" viewBox="100 60 20 20" />
     <g transform="translate(100 60)">
@@ -303,7 +334,7 @@
       <path d="M 14.5 12 v 6" class="s" />
     </g>
     <view id="prison_11" viewBox="120 60 20 20" />
-    <g transform="translate(120 60)" class="s" stroke-width="1.5">
+    <g transform="translate(120 60)" class="s w15">
       <rect x="4" y="3" width="12" height="14" />
       <rect x="8" y="3" width="4" height="14" />
       <rect x="12" y="8" width="4" height="4" />
@@ -323,7 +354,7 @@
     </g>
     <view id="grocery_11" viewBox="20 80 20 20" />
     <g transform="translate(20 80)">
-      <path d="M 15 6 h -12 l 2 7 h 10 v -7 l 1 -4 h 2" class="s" stroke-width="1.5" />
+      <path d="M 15 6 h -12 l 2 7 h 10 v -7 l 1 -4 h 2" class="s w15" />
       <path d="M 15 6 h -12 l 2 7 h 10 z" class="f" />
       <circle cx="6" cy="16" r="1.5" class="f" />
       <circle cx="14" cy="16" r="1.5" class="f" />
@@ -331,7 +362,7 @@
     <view id="suitcase_11" viewBox="40 80 20 20" />
     <g transform="translate(40 80)">
       <rect x="3" y="6" width="14" height="11" rx="1" class="f" />
-      <rect x="7" y="3" width="6" height="12" rx="1" class="s" stroke-width="1.5" />
+      <rect x="7" y="3" width="6" height="12" rx="1" class="s w15" />
     </g>
     <view id="alcohol_shop_11" viewBox="60 80 20 20" />
     <g transform="translate(60 80)">
@@ -377,20 +408,20 @@
       <rect x="3" y="9" width="14" height="6" rx="1" class="f" mask="url(#car_11_mask)" />
       <rect x="4" y="14" width="3" height="4" class="f" rx="1" />
       <rect x="13" y="14" width="3" height="4" class="f" rx="1" />
-      <path d="M 4 10 l 2 -6 h 8 l 2 6" class="s" stroke-width="1.5" />
+      <path d="M 4 10 l 2 -6 h 8 l 2 6" class="s w15" />
     </g>
     <view id="art_gallery_11" viewBox="140 80 20 20" />
     <g transform="translate(140 80)">
-      <rect x="4" y="6" width="12" height="10" class="s" stroke-width="1.5" />
+      <rect x="4" y="6" width="12" height="10" class="s w15" />
       <circle cx="7" cy="9" r="1" class="f" />
       <path d="M 8 14 l 1 -2 l 1 2 l 2 -5 l 2 5 z" class="f" />
-      <path d="M 5 6 L 10 2 L 15 6" class="s" stroke-width="1.2" />
+      <path d="M 5 6 L 10 2 L 15 6" class="s w12" />
     </g>
     <!-- 店舗系2行目 -->
     <view id="bank_11" viewBox="0 100 20 20" />
     <g transform="translate(0 100)">
-      <rect x="2" y="5" width="16" height="10" class="s" stroke-width="1.5" />
-      <ellipse cx="10" cy="10" rx="2.5" ry="3" class="s" stroke-width="1.5" />
+      <rect x="2" y="5" width="16" height="10" class="s w15" />
+      <ellipse cx="10" cy="10" rx="2.5" ry="3" class="s w15" />
       <path d="M 6 7 h -2 v 2" class="s" />
       <path d="M 6 13 h -2 v -2" class="s" />
       <path d="M 14 7 h 2 v 2" class="s" />
@@ -398,8 +429,8 @@
     </g>
     <view id="lodging_11" viewBox="20 100 20 20" />
     <g transform="translate(20 100)">
-      <path d="M 3 15 v -3 h 14 v 3" class="s" stroke-width="1.5" />
-      <path d="M 3 5 v 8" class="s" stroke-width="1.5" />
+      <path d="M 3 15 v -3 h 14 v 3" class="s w15" />
+      <path d="M 3 5 v 8" class="s w15" />
       <circle cx="6.5" cy="8" r="1.5" class="f" />
       <path d="M 9 6 h 4 q 3 0 3.5 3.5 h -7.5 z" class="f" />
     </g>
@@ -408,7 +439,7 @@
       <rect x="3" y="10" width="11" height="7" class="f" />
       <circle cx="5" cy="7" r="1.5" class="s" />
       <circle cx="11" cy="6" r="2.5" class="s" />
-      <path d="M 13 12 h 3.5 v -1.5 v 3" class="s" stroke-width="1.5" />
+      <path d="M 13 12 h 3.5 v -1.5 v 3" class="s w15" />
     </g>
     <view id="laundry_11" viewBox="60 100 20 20" />
     <g transform="translate(60 100)">
@@ -426,23 +457,23 @@
     <g transform="translate(80 100)">
       <circle cx="5" cy="16" r="1.5" class="fs" />
       <circle cx="15" cy="14" r="1.5" class="fs" />
-      <path d="M 6.5 16 v -12 l 10 -2 v 12" class="s" stroke-width="1.5" />
-      <path d="M 6.5 8 l 10 -2" class="s" stroke-width="1.5" />
+      <path d="M 6.5 16 v -12 l 10 -2 v 12" class="s w15" />
+      <path d="M 6.5 8 l 10 -2" class="s w15" />
     </g>
     <view id="bicycle_11" viewBox="100 100 20 20" />
     <g transform="translate(100 100)">
-      <circle cx="5" cy="14" r="3" class="s" stroke-width="1.4" />
-      <circle cx="15" cy="14" r="3" class="s" stroke-width="1.4" />
-      <path d="M 6 8 l 1 3 l 6 -3" class="s" stroke-width="1.5" />
-      <path d="M 4 7 h 3" class="s" stroke-width="2" />
-      <path d="M 10 4 h 2 l 2 6" class="s" stroke-width="1.5" />
+      <circle cx="5" cy="14" r="3" class="s w14" />
+      <circle cx="15" cy="14" r="3" class="s w14" />
+      <path d="M 6 8 l 1 3 l 6 -3" class="s w15" />
+      <path d="M 4 7 h 3" class="s w20" />
+      <path d="M 10 4 h 2 l 2 6" class="s w15" />
     </g>
     <!-- 食事系 -->
     <view id="fast_food_11" viewBox="0 120 20 20" />
     <g transform="translate(0 120)">
-      <path d="M10 4 q -6 0 -6 3 h 12 q 0 -3 -6 -3" class="fs" stroke-width="1.5" />
+      <path d="M10 4 q -6 0 -6 3 h 12 q 0 -3 -6 -3" class="fs w15" />
       <rect x="2.5" y="9.5" width="15" height="3" rx="2" class="f" />
-      <path d="M 4 15 l 1 1 h 10 l 1 -1 z" class="fs" stroke-width="1.5" />
+      <path d="M 4 15 l 1 1 h 10 l 1 -1 z" class="fs w15" />
     </g>
     <view id="restaurant_11" viewBox="20 120 20 20" />
     <g transform="translate(20 120)">
@@ -453,34 +484,34 @@
     </g>
     <view id="bakery_11" viewBox="40 120 20 20" />
     <g transform="translate(40 120)">
-      <path d="M 5 8 v 8 h 10 v -8 a 6.5 3 0 1 0 -10 0 z" class="fs" stroke-width="1.5" />
+      <path d="M 5 8 v 8 h 10 v -8 a 6.5 3 0 1 0 -10 0 z" class="fs w15" />
     </g>
     <view id="cafe_11" viewBox="60 120 20 20" />
     <g transform="translate(60 120)">
       <rect x="4" y="4" width="10" height="6" rx="1" class="f" />
       <rect x="4" y="7" width="10" height="6" rx="3" ry="4" class="f" />
-      <path d="M 12 6 h 3 a 2 2 0 0 1 0 4 h -3" class="s" stroke-width="1.5" />
+      <path d="M 12 6 h 3 a 2 2 0 0 1 0 4 h -3" class="s w15" />
       <path d="M 3 15 h 12 l -1 1 h -10 z" class="fs" />
     </g>
     <view id="bar_11" viewBox="80 120 20 20" />
     <g transform="translate(80 120)">
-      <path d="M 10 3 h -7 l 7 7 v 6 l -4 1 h 4" class="s" stroke-width="1.5" />
-      <path d="M 10 3 h -7 l 7 7 v 6 l -4 1 h 4" class="s" stroke-width="1.5" transform="translate(20 0) scale(-1 1)" />
+      <path d="M 10 3 h -7 l 7 7 v 6 l -4 1 h 4" class="s w15" />
+      <path d="M 10 3 h -7 l 7 7 v 6 l -4 1 h 4" class="s w15" transform="translate(20 0) scale(-1 1)" />
       <path d="M 6 6 l 4 4 l 4 -4 z" class="f" />
     </g>
     <view id="beer_11" viewBox="100 120 20 20" />
     <g transform="translate(100 120)">
       <rect x="4" y="7" width="9" height="8" class="f" />
       <rect x="4" y="7" width="9" height="11" rx="1" class="f" />
-      <path d="M 12 9 h 2 q 2 0 2 2 v 2 q 0 2 -2 2 h -2" class="s" stroke-width="1.5" />
-      <path d="M 4 6 q -1 -1 1 -2 q 0.5 -2 3 -1 q 3 -2 4 1 q 2 1 1 2" class="s" stroke-width="1.2" />
+      <path d="M 12 9 h 2 q 2 0 2 2 v 2 q 0 2 -2 2 h -2" class="s w15" />
+      <path d="M 4 6 q -1 -1 1 -2 q 0.5 -2 3 -1 q 3 -2 4 1 q 2 1 1 2" class="s w12" />
     </g>
     <view id="ice_cream_11" viewBox="120 120 20 20" />
     <g transform="translate(120 120)">
-      <path d="M 6 8 a 0.7 0.5 0 0 1 0 -1 a 4 4 0 0 1 8 0 a 0.7 0.5 0 0 1 0 1" class="fs" stroke-width="1.2" />
-      <path d="M 6 8 L 10 17 L 14 8 z" class="s" stroke-width="1.2" />
-      <path d="M 8 11 l 1 -2" class="s" stroke-width="1" />
-      <path d="M 9 13 l 1 -2" class="s" stroke-width="1" />
+      <path d="M 6 8 a 0.7 0.5 0 0 1 0 -1 a 4 4 0 0 1 8 0 a 0.7 0.5 0 0 1 0 1" class="fs w12" />
+      <path d="M 6 8 L 10 17 L 14 8 z" class="s w12" />
+      <path d="M 8 11 l 1 -2" class="s" />
+      <path d="M 9 13 l 1 -2" class="s" />
     </g>
     <!-- アクティビティ系1行目 -->
     <view id="attraction_11" viewBox="0 140 20 20" />
@@ -493,7 +524,7 @@
         </mask>
       </defs>
       <rect x="3" y="6" width="14" height="10" rx="1" class="f" mask="url(#attraction_11_mask)" />
-      <path d="M 8 6 l 1 -1 h 2 l 1 1 z" class="fs" stroke-width="2" />
+      <path d="M 8 6 l 1 -1 h 2 l 1 1 z" class="fs w20" />
     </g>
     <view id="museum_11" viewBox="20 140 20 20" />
     <g transform="translate(20 140)">
@@ -534,7 +565,7 @@
     </g>
     <view id="amusement_park_11" viewBox="80 140 20 20" />
     <g transform="translate(80 140)">
-      <circle cx="10" cy="9" r="6" class="s" stroke-width="1.5" />
+      <circle cx="10" cy="9" r="6" class="s w15" />
       <circle cx="10" cy="9" r="2.5" class="f" />
       <path d="M 10 4 v 10" class="s" />
       <path d="M 6 5 l 8 8" class="s" />
@@ -566,7 +597,7 @@
       <rect x="9" y="2" width="2" height="5" class="f" />
       <rect x="14" y="2" width="2" height="5" class="f" />
       <rect x="4" y="5" width="12" height="2" class="f" />
-      <path d="M 3 17 h 14" class="s" stroke-width="2" />
+      <path d="M 3 17 h 14" class="s w20" />
       <path d="M 5 17 l 2 -8 h 6 l 2 8" class="fs" mask="url(#castle_11_mask)" />
     </g>
     <view id="theatre_11" viewBox="140 140 20 20" />
@@ -606,13 +637,13 @@
           <circle cx="7" cy="9" r="2" fill="black" />
         </mask>
       </defs>
-      <path d="M 7 2 l -4 4 h 8 z" class="fs" stroke-width="1.8" />
+      <path d="M 7 2 l -4 4 h 8 z" class="fs w18" />
       <rect x="3" y="6" width="8" height="7" class="f" mask="url(#playground_11_mask)" />
-      <path d="M 4 10 v 8" class="s" stroke-width="1.5" />
-      <path d="M 10 10 v 8" class="s" stroke-width="1.5" />
-      <path d="M 4 14.5 h 6" class="s" stroke-width="1.2" />
-      <path d="M 4 17 h 6" class="s" stroke-width="1.2" />
-      <path d="M 10 11 h 3 l 3 7 h 2" class="s" stroke-width="2" />
+      <path d="M 4 10 v 8" class="s w15" />
+      <path d="M 10 10 v 8" class="s w15" />
+      <path d="M 4 14.5 h 6" class="s w12" />
+      <path d="M 4 17 h 6" class="s w12" />
+      <path d="M 10 11 h 3 l 3 7 h 2" class="s w20" \ />
     </g>
     <view id="campsite_11" viewBox="60 160 20 20" />
     <g transform="translate(60 160)">
@@ -621,11 +652,11 @@
     </g>
     <view id="picnic_site_11" viewBox="80 160 20 20" />
     <g transform="translate(80 160)">
-      <path d="M 7 5 h 6" class="s" stroke-width="2" />
-      <path d="M 8 7 l -3 10" class="s" stroke-width="1.5" />
-      <path d="M 12 7 l 3 10" class="s" stroke-width="1.5" />
-      <path d="M 4 11 h 4" class="s" stroke-width="2" />
-      <path d="M 12 11 h 4" class="s" stroke-width="2" />
+      <path d="M 7 5 h 6" class="s w20" \ />
+      <path d="M 8 7 l -3 10" class="s w15" />
+      <path d="M 12 7 l 3 10" class="s w15" />
+      <path d="M 4 11 h 4" class="s w20" \ />
+      <path d="M 12 11 h 4" class="s w20" \ />
     </g>
     <view id="zoo_11" viewBox="100 160 20 20" />
     <g transform="translate(100 160)">
@@ -633,7 +664,7 @@
         <mask id="zoo_11_mask">
           <rect x="0" y="0" width="20" height="20" fill="white" />
           <circle cx="6" cy="8.5" r="1.2" fill="black" />
-          <path d="M 7 5 a 2 3 0 0 1 3 5" fill="none" stroke="black" stroke-width="1" />
+          <path d="M 7 5 a 2 3 0 0 1 3 5" fill="none" stroke="black" />
         </mask>
       </defs>
       <path
@@ -661,7 +692,7 @@
     <!-- アクティビティ系3行目 -->
     <view id="mountain_11" viewBox="0 180 20 20" />
     <g transform="translate(0 180)">
-      <path d="M 3 16 L 10 3 L 17 16 z" class="s" stroke-width="1.5" />
+      <path d="M 3 16 L 10 3 L 17 16 z" class="s w15" />
       <path d="M 3 16 L 5 14 L 8.5 11 L 10 13 L 11.5 11 L 15 14 L 17 16 z" class="f" />
     </g>
     <view id="volcano_11" viewBox="20 180 20 20" />
@@ -674,20 +705,20 @@
           <path d="M 12 5 v 5" fill="none" stroke="black" stroke-width="2" />
         </mask>
       </defs>
-      <path d="M 3 16 L 10 3 L 17 16 z" class="fs" stroke-width="1.5" mask="url(#volcano_11_mask)" />
+      <path d="M 3 16 L 10 3 L 17 16 z" class="fs w15" mask="url(#volcano_11_mask)" />
       <path d="M 8 6 l -3 -3 l 3 2 l 1 -3 l 1 3 l 4 -1 l -3 2 z" class="fs" />
     </g>
     <view id="golf_11" viewBox="40 180 20 20" />
     <g transform="translate(40 180)">
-      <path d="M 6 8 L 15 5 L 6 8 L 7 12 L 6 17 L 7 12 L 10 12 L 10 17 L 10 12 L 9 8 z" class="fs" stroke-width="2" />
+      <path d="M 6 8 L 15 5 L 6 8 L 7 12 L 6 17 L 7 12 L 10 12 L 10 17 L 10 12 L 9 8 z" class="fs w20" />
       <circle cx="6" cy="4" r="1.5" class="f" />
-      <path d="M 16 5 l -5 -3" class="fs" stroke-width="1.2" />
+      <path d="M 16 5 l -5 -3" class="fs w12" />
       <circle cx="10" cy="2" r="1.2" class="f" />
     </g>
     <view id="swimming_11" viewBox="60 180 20 20" />
     <g transform="translate(60 180)">
-      <path d="M 14 3 l -6 4 l 5 5 h -7 l 3 -3 v 2 h 1" class="s" stroke-width="2" />
-      <path d="M 3 16 l 2.4 -1 l 2.4 1 l 2.4 -1 l 2.4 1 l 2.4 -1 l 2.4 1" class="s" stroke-width="1.5" />
+      <path d="M 14 3 l -6 4 l 5 5 h -7 l 3 -3 v 2 h 1" class="s w20" />
+      <path d="M 3 16 l 2.4 -1 l 2.4 1 l 2.4 -1 l 2.4 1 l 2.4 -1 l 2.4 1" class="s w15" />
       <circle cx="14.5" cy="8" r="1.5" class="f" />
     </g>
     <!-- 信仰系 -->
@@ -706,10 +737,9 @@
           <rect x="8" y="7" width="4" height="2" fill="black" />
         </mask>
       </defs>
-      <path d="M 10 3 h -1 l -1 1 h -2l 2 10 h -2 v 2 h 4 z" class="fs" stroke-width="1.5"
+      <path d="M 10 3 h -1 l -1 1 h -2l 2 10 h -2 v 2 h 4 z" class="fs w15" mask="url(#cemetery_11_mask)" />
+      <path d="M 10 3 h -1 l -1 1 h -2 l 2 10 h -2 v 2 h 4 z" transform="translate(20) scale(-1 1)" class="fs w15"
         mask="url(#cemetery_11_mask)" />
-      <path d="M 10 3 h -1 l -1 1 h -2 l 2 10 h -2 v 2 h 4 z" transform="translate(20) scale(-1 1)" class="fs"
-        stroke-width="1.5" mask="url(#cemetery_11_mask)" />
     </g>
     <view id="religious_christian_11" viewBox="40 200 20 20" />
     <g transform="translate(40 200)">
@@ -738,19 +768,19 @@
     </g>
     <view id="circle_11" viewBox="40 220 20 20" />
     <g transform="translate(40 220)">
-      <circle cx="10" cy="10" r="6" class="fs" stroke-width="1.5" />
+      <circle cx="10" cy="10" r="6" class="fs w15" />
     </g>
     <view id="circle_stroked_11" viewBox="60 220 20 20" />
     <g transform="translate(60 220)">
-      <circle cx="10" cy="10" r="6" class="s" stroke-width="1.5" />
+      <circle cx="10" cy="10" r="6" class="s w15" />
     </g>
     <view id="triangle_11" viewBox="80 220 20 20" />
     <g transform="translate(80 220)">
-      <path d="M 10 4 L 4 15 L 16 15 z" class="fs" stroke-width="1.5" />
+      <path d="M 10 4 L 4 15 L 16 15 z" class="fs w15" />
     </g>
     <view id="triangle_11" viewBox="100 220 20 20" />
     <g transform="translate(100 220)">
-      <path d="M 10 4 L 4 15 L 16 15 z" class="s" stroke-width="1.5" />
+      <path d="M 10 4 L 4 15 L 16 15 z" class="s w15" />
     </g>
     <!-- <g fill="none" stroke="red" stroke-width="0.2">
       <path


### PR DESCRIPTION
## 概要

Dark のスプライトの SVG をリファクタリングする。

主に以下の内容を実施。

- 線・塗り・その両方をスタイルで定義して `class` として指定
- 線幅をスタイルで定義して `class` として指定

変更前後で表示内容に差分がないことを確認済み。

変更前 | 変更後
:--: | :--:
<img width="269" height="399" alt="image" src="https://github.com/user-attachments/assets/04f8a861-0bf6-4bbd-b91b-9892f59e8892" /> | <img width="270" height="399" alt="image" src="https://github.com/user-attachments/assets/d465f5e3-65e9-42c7-9540-ec1da90e7dbf" />

### 備考

マスクの定義・指定部分は未対応。ほとんど `fill` のみであること、VSCode で色が表示されることから現状でも見やすいためであるが、後ほど検討する。

## モチベーション

SVG ファイルの見通しを良くしてメンテナンス性を向上させる。
