### PR TITLE
chore: プロダクトコードでは使用しない svg2png-wasm を devDependencies へ移動

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,8 +15,7 @@
     "maplibre-gl": "^5.8.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "react-map-gl": "^8.1.0",
-    "svg2png-wasm": "^1.4.1"
+    "react-map-gl": "^8.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.36.0",
@@ -30,6 +29,7 @@
     "eslint-plugin-react-refresh": "^0.4.22",
     "eslint-plugin-react-x": "^2.0.6",
     "globals": "^16.4.0",
+    "svg2png-wasm": "^1.4.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.45.0",
     "vite": "^7.1.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       react-map-gl:
         specifier: ^8.1.0
         version: 8.1.0(maplibre-gl@5.8.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      svg2png-wasm:
-        specifier: ^1.4.1
-        version: 1.4.1
     devDependencies:
       '@eslint/js':
         specifier: ^9.36.0
@@ -57,6 +54,9 @@ importers:
       globals:
         specifier: ^16.4.0
         version: 16.4.0
+      svg2png-wasm:
+        specifier: ^1.4.1
+        version: 1.4.1
       typescript:
         specifier: ~5.9.3
         version: 5.9.3


### PR DESCRIPTION
プロダクトコードでは使用しない svg2png-wasm を、dependencies から devDependencies へ移動する。

## モチベーション

依存を整理してシンプルにするため。

## 確認した内容

`pnpm sprite` を実行後、ローカル環境でエラーなく正常にスプライトが生成・表示されることを確認した。
