### PR TITLE
style: 地図スタイル選択ボタンのスタイルをソリッドに変更

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -12,7 +12,7 @@
   position: absolute;
   top: 0.5rem;
   left: 0.5rem;
-  background: hsl(0 0% 100% / 60%);
+  background: hsl(0 0% 100% / 80%);
   padding: 0.5rem;
   border-radius: 0.4rem;
   line-height: 1;
@@ -20,19 +20,40 @@
   #button-wrapper {
     display: flex;
     flex-direction: column;
-    gap: 0.4rem;
+    gap: 0.6rem;
   }
 
   button {
-    background: linear-gradient(to bottom, hsl(0 0% 100%) 50%, hsl(0 0% 80%) 100%);
-    color: hsl(0 0% 20%);
-    border: solid 1px hsl(0 0% 95%);
-    border-radius: 0.4rem;
-    padding: 0.1rem 0.4rem;
+    background: none;
+    color: hsl(200 50% 30%);
+    border: solid 2px transparent;
+    border-top-color: hsl(200 50% 50% / 50%);
+    border-bottom-color: hsl(200 50% 50% / 50%);
+    padding: 0.1rem 0.2rem 0.2rem;
+    font-weight: bold;
     cursor: pointer;
+    transition: all 0.5s;
+  }
+  button::before {
+    content: ">> ";
+    color: transparent;
+    padding-right: 0.5rem;
+    transition: all 0.5s;
+  }
+  button::after {
+    content: " <<";
+    color: transparent;
+    padding-left: 0.5rem;
+    transition: all 0.5s;
   }
   button.selected {
-    background: linear-gradient(to bottom, hsl(0 0% 70%) 0%, hsl(0 0% 100%) 60%);
-    border-color: hsl(0 0% 80%);
+    border-top-color: hsl(200 50% 50%);
+    border-bottom-color: hsl(200 50% 50%);
+    transition: all 0.5s;
+  }
+  button.selected::before,
+  button.selected::after {
+    color: hsl(200 50% 50%);
+    transition: all 0.5s;
   }
 }


### PR DESCRIPTION
## 概要

画面左上にある、地図スタイル選択ボタンのスタイルをソリッドに変更する。

従来 | 変更後
:--: | :--:
<img width="63" height="65" alt="image" src="https://github.com/user-attachments/assets/df38d366-553c-4d47-8c7b-8232adc7fccc" /> | <img width="110" height="77" alt="image" src="https://github.com/user-attachments/assets/b7f6c50f-53b8-486c-b8d3-3bb3ee5d72a9" />


## 背景/モチベーション

従来のボタンでは選択状態が分かりづらかったため、見やすくする。
