### PR TITLE
feat: AttributionControl の表示状態制御をデフォルトに設定

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,6 @@ export function App() {
           zoom: 7,
         }}
         mapStyle={STYLES[selectedStyleIndex].json}
-        attributionControl={false}
       >
         <ScaleControl />
         <NavigationControl />


### PR DESCRIPTION
## 概要

これまではデバッグ用に `AttributionControl` （画面右下に表示される「i」）を常に非表示にしていたが、表示状態制御をデフォルトに設定する。

これによりライセンス表示がライブラリデフォルトの挙動となる。初期状態ではテキスト部分が表示されていて、地図を表示すると閉じてアイコンのみとなる。

&nbsp; | 初期表示状態 | アイコンのみ
:--: | :--: | :--:
変更後の表示 | <img width="404" height="41" alt="image" src="https://github.com/user-attachments/assets/165a455c-9922-41e4-a23c-6209758805f2" /> | <img width="40" height="41" alt="image" src="https://github.com/user-attachments/assets/011acc3b-5527-40bf-9388-eef86522c585" />


## やったこと

- 地図初期化時に `AttributionControl` へのオプション付与を削除

## やらないこと / 今後やること

- 

## 関連チケット

- 
