### PR TITLE
feat: 座標等を URL に埋め込み

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,17 +42,13 @@ const DEFAULT_STYLE_INDEX = 0;
  */
 function parseNumericQueryParam(params: URLSearchParams, key: string) {
   const rawValue = params.get(key);
-
   if (rawValue === null) {
     return null;
   }
-
   const parsedValue = Number(rawValue);
-
   if (!Number.isFinite(parsedValue)) {
     return null;
   }
-
   return parsedValue;
 }
 
@@ -86,7 +82,6 @@ function parseInitialUrlState(): InitialUrlState {
 
   if (styleKey !== null) {
     const parsedStyleIndex = STYLES.findIndex((style) => style.key === styleKey.toLowerCase());
-
     if (parsedStyleIndex === -1) {
       shouldRewriteUrl = true;
     } else {
@@ -126,7 +121,6 @@ export function App() {
     if (!initialUrlState.shouldRewriteUrl) {
       return;
     }
-
     updateUrlFromState(initialUrlState.viewState, initialUrlState.styleIndex);
   }, [initialUrlState]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Map, {
   FullscreenControl,
   GeolocateControl,
@@ -21,6 +21,12 @@ type MapView = {
   latitude: number;
   longitude: number;
   zoom: number;
+};
+
+type InitialUrlState = {
+  viewState: MapView;
+  styleIndex: number;
+  shouldRewriteUrl: boolean;
 };
 
 const DEFAULT_VIEW_STATE: MapView = {
@@ -51,43 +57,48 @@ function parseNumericQueryParam(params: URLSearchParams, key: string) {
 }
 
 /**
- * URL に含まれる座標とズーム値から地図の初期表示位置を組み立てる。
+ * URL から初期表示に使う地図状態を読み取り、不正な指定の有無も返す。
  */
-function parseViewStateFromUrl(): MapView {
+function parseInitialUrlState(): InitialUrlState {
   const params = new URLSearchParams(window.location.search);
   const latitude = parseNumericQueryParam(params, "lat");
   const longitude = parseNumericQueryParam(params, "lng");
   const zoom = parseNumericQueryParam(params, "zoom");
+  const styleKey = params.get("style");
+  const hasViewParams = params.has("lat") || params.has("lng") || params.has("zoom");
+  const hasCompleteViewParams = params.has("lat") && params.has("lng") && params.has("zoom");
 
-  if (latitude === null || longitude === null || zoom === null) {
-    return DEFAULT_VIEW_STATE;
+  let viewState = DEFAULT_VIEW_STATE;
+  let styleIndex = DEFAULT_STYLE_INDEX;
+  let shouldRewriteUrl = false;
+
+  if (hasViewParams) {
+    if (hasCompleteViewParams && latitude !== null && longitude !== null && zoom !== null) {
+      viewState = {
+        latitude,
+        longitude,
+        zoom,
+      };
+    } else {
+      shouldRewriteUrl = true;
+    }
+  }
+
+  if (styleKey !== null) {
+    const parsedStyleIndex = STYLES.findIndex((style) => style.key === styleKey.toLowerCase());
+
+    if (parsedStyleIndex === -1) {
+      shouldRewriteUrl = true;
+    } else {
+      styleIndex = parsedStyleIndex;
+    }
   }
 
   return {
-    latitude,
-    longitude,
-    zoom,
+    viewState,
+    styleIndex,
+    shouldRewriteUrl,
   };
-}
-
-/**
- * URL に含まれるスタイル名を読み取り、不正値は既定値へ戻す。
- */
-function parseStyleIndexFromUrl() {
-  const params = new URLSearchParams(window.location.search);
-  const styleKey = params.get("style");
-
-  if (styleKey === null) {
-    return DEFAULT_STYLE_INDEX;
-  }
-
-  const styleIndex = STYLES.findIndex((style) => style.key === styleKey.toLowerCase());
-
-  if (styleIndex === -1) {
-    return DEFAULT_STYLE_INDEX;
-  }
-
-  return styleIndex;
 }
 
 /**
@@ -106,9 +117,18 @@ function updateUrlFromState(viewState: MapView, styleIndex: number) {
  * 地図本体とスタイル切替 UI を表示する。
  */
 export function App() {
-  const [initialViewState] = useState<MapView>(() => parseViewStateFromUrl());
-  const [currentViewState, setCurrentViewState] = useState<MapView>(() => parseViewStateFromUrl());
-  const [selectedStyleIndex, setSelectedStyleIndex] = useState<number>(() => parseStyleIndexFromUrl());
+  const [initialUrlState] = useState<InitialUrlState>(() => parseInitialUrlState());
+  const [currentViewState, setCurrentViewState] = useState<MapView>(initialUrlState.viewState);
+  const [selectedStyleIndex, setSelectedStyleIndex] = useState<number>(initialUrlState.styleIndex);
+
+  /** 不正な URL パラメータでアクセスされた場合に、表示中の状態へ URL を補正する */
+  useEffect(() => {
+    if (!initialUrlState.shouldRewriteUrl) {
+      return;
+    }
+
+    updateUrlFromState(initialUrlState.viewState, initialUrlState.styleIndex);
+  }, [initialUrlState]);
 
   /** 選択中の地図スタイルを更新する */
   const handleStyleChange = useCallback(
@@ -130,7 +150,7 @@ export function App() {
 
   return (
     <div id="map">
-      <Map initialViewState={initialViewState} mapStyle={STYLES[selectedStyleIndex].json} onMove={handleMove}>
+      <Map initialViewState={initialUrlState.viewState} mapStyle={STYLES[selectedStyleIndex].json} onMove={handleMove}>
         <ScaleControl />
         <NavigationControl />
         <FullscreenControl />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,8 +13,8 @@ import * as lightStyleJson from "../public/light/style.json";
 
 /** 地図スタイルのデータのリスト */
 const STYLES = [
-  { name: "Dark", json: darkStyleJson as unknown as StyleSpecification },
-  { name: "Light", json: lightStyleJson as unknown as StyleSpecification },
+  { key: "dark", name: "Dark", json: darkStyleJson as unknown as StyleSpecification },
+  { key: "light", name: "Light", json: lightStyleJson as unknown as StyleSpecification },
 ];
 
 type MapView = {
@@ -28,6 +28,8 @@ const DEFAULT_VIEW_STATE: MapView = {
   longitude: 138,
   zoom: 7,
 };
+
+const DEFAULT_STYLE_INDEX = 0;
 
 /**
  * URL クエリから数値パラメータを読み取り、不正値は null として扱う。
@@ -69,13 +71,34 @@ function parseViewStateFromUrl(): MapView {
 }
 
 /**
- * 現在の地図表示位置を URL クエリへ反映する。
+ * URL に含まれるスタイル名を読み取り、不正値は既定値へ戻す。
  */
-function updateUrlFromViewState(viewState: MapView) {
+function parseStyleIndexFromUrl() {
+  const params = new URLSearchParams(window.location.search);
+  const styleKey = params.get("style");
+
+  if (styleKey === null) {
+    return DEFAULT_STYLE_INDEX;
+  }
+
+  const styleIndex = STYLES.findIndex((style) => style.key === styleKey.toLowerCase());
+
+  if (styleIndex === -1) {
+    return DEFAULT_STYLE_INDEX;
+  }
+
+  return styleIndex;
+}
+
+/**
+ * 現在の地図表示位置とスタイルを URL クエリへ反映する。
+ */
+function updateUrlFromState(viewState: MapView, styleIndex: number) {
   const url = new URL(window.location.href);
   url.searchParams.set("lat", viewState.latitude.toFixed(6));
   url.searchParams.set("lng", viewState.longitude.toFixed(6));
   url.searchParams.set("zoom", viewState.zoom.toFixed(2));
+  url.searchParams.set("style", STYLES[styleIndex].key);
   window.history.replaceState(null, "", url);
 }
 
@@ -83,18 +106,27 @@ function updateUrlFromViewState(viewState: MapView) {
  * 地図本体とスタイル切替 UI を表示する。
  */
 export function App() {
-  const [selectedStyleIndex, setSelectedStyleIndex] = useState<number>(0);
   const [initialViewState] = useState<MapView>(() => parseViewStateFromUrl());
+  const [currentViewState, setCurrentViewState] = useState<MapView>(() => parseViewStateFromUrl());
+  const [selectedStyleIndex, setSelectedStyleIndex] = useState<number>(() => parseStyleIndexFromUrl());
 
   /** 選択中の地図スタイルを更新する */
-  const handleStyleChange = useCallback((index: number) => {
-    setSelectedStyleIndex(index);
-  }, []);
+  const handleStyleChange = useCallback(
+    (index: number) => {
+      setSelectedStyleIndex(index);
+      updateUrlFromState(currentViewState, index);
+    },
+    [currentViewState],
+  );
 
   /** 地図の移動やズームに応じて URL を更新する */
-  const handleMove = useCallback((event: { viewState: MapView }) => {
-    updateUrlFromViewState(event.viewState);
-  }, []);
+  const handleMove = useCallback(
+    (event: { viewState: MapView }) => {
+      setCurrentViewState(event.viewState);
+      updateUrlFromState(event.viewState, selectedStyleIndex);
+    },
+    [selectedStyleIndex],
+  );
 
   return (
     <div id="map">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,23 +17,84 @@ const STYLES = [
   { name: "Light", json: lightStyleJson as unknown as StyleSpecification },
 ];
 
+type MapView = {
+  latitude: number;
+  longitude: number;
+  zoom: number;
+};
+
+const DEFAULT_VIEW_STATE: MapView = {
+  latitude: 36,
+  longitude: 138,
+  zoom: 7,
+};
+
+/**
+ * URL クエリから数値パラメータを読み取り、不正値は null として扱う。
+ */
+function parseNumericQueryParam(params: URLSearchParams, key: string) {
+  const rawValue = params.get(key);
+
+  if (rawValue === null) {
+    return null;
+  }
+
+  const parsedValue = Number(rawValue);
+
+  if (!Number.isFinite(parsedValue)) {
+    return null;
+  }
+
+  return parsedValue;
+}
+
+/**
+ * URL に含まれる座標とズーム値から地図の初期表示位置を組み立てる。
+ */
+function parseViewStateFromUrl(): MapView {
+  const params = new URLSearchParams(window.location.search);
+  const latitude = parseNumericQueryParam(params, "lat");
+  const longitude = parseNumericQueryParam(params, "lng");
+  const zoom = parseNumericQueryParam(params, "zoom");
+
+  if (latitude === null || longitude === null || zoom === null) {
+    return DEFAULT_VIEW_STATE;
+  }
+
+  return {
+    latitude,
+    longitude,
+    zoom,
+  };
+}
+
+/**
+ * 現在の地図表示位置を URL クエリへ反映する。
+ */
+function updateUrlFromViewState(viewState: MapView) {
+  const url = new URL(window.location.href);
+  url.searchParams.set("lat", viewState.latitude.toFixed(6));
+  url.searchParams.set("lng", viewState.longitude.toFixed(6));
+  url.searchParams.set("zoom", viewState.zoom.toFixed(2));
+  window.history.replaceState(null, "", url);
+}
+
 export function App() {
   const [selectedStyleIndex, setSelectedStyleIndex] = useState<number>(0);
+  const [initialViewState] = useState<MapView>(() => parseViewStateFromUrl());
 
   const handleStyleChange = useCallback((index: number) => {
     setSelectedStyleIndex(index);
   }, []);
 
+  /** 地図の移動やズームに応じて URL を更新する */
+  const handleMove = useCallback((event: { viewState: MapView }) => {
+    updateUrlFromViewState(event.viewState);
+  }, []);
+
   return (
     <div id="map">
-      <Map
-        initialViewState={{
-          latitude: 36,
-          longitude: 138,
-          zoom: 7,
-        }}
-        mapStyle={STYLES[selectedStyleIndex].json}
-      >
+      <Map initialViewState={initialViewState} mapStyle={STYLES[selectedStyleIndex].json} onMove={handleMove}>
         <ScaleControl />
         <NavigationControl />
         <FullscreenControl />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,24 +10,13 @@ import "maplibre-gl/dist/maplibre-gl.css";
 import "./App.css";
 import * as darkStyleJson from "../public/dark/style.json";
 import * as lightStyleJson from "../public/light/style.json";
+import type { MapView, InitialUrlState } from "./types";
 
 /** 地図スタイルのデータのリスト */
 const STYLES = [
   { key: "dark", name: "Dark", json: darkStyleJson as unknown as StyleSpecification },
   { key: "light", name: "Light", json: lightStyleJson as unknown as StyleSpecification },
 ];
-
-type MapView = {
-  latitude: number;
-  longitude: number;
-  zoom: number;
-};
-
-type InitialUrlState = {
-  viewState: MapView;
-  styleIndex: number;
-  shouldRewriteUrl: boolean;
-};
 
 const DEFAULT_VIEW_STATE: MapView = {
   latitude: 36,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,30 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
-import Map, {
-  FullscreenControl,
-  GeolocateControl,
-  NavigationControl,
-  ScaleControl,
-  type StyleSpecification,
-} from "react-map-gl/maplibre";
+import Map, { FullscreenControl, GeolocateControl, NavigationControl, ScaleControl } from "react-map-gl/maplibre";
 import "maplibre-gl/dist/maplibre-gl.css";
 import "./App.css";
-import * as darkStyleJson from "../public/dark/style.json";
-import * as lightStyleJson from "../public/light/style.json";
 import type { MapView, InitialUrlState } from "./types";
-
-/** 地図スタイルのデータのリスト */
-const STYLES = [
-  { key: "dark", name: "Dark", json: darkStyleJson as unknown as StyleSpecification },
-  { key: "light", name: "Light", json: lightStyleJson as unknown as StyleSpecification },
-];
-
-const DEFAULT_VIEW_STATE: MapView = {
-  latitude: 36,
-  longitude: 138,
-  zoom: 7,
-};
-
-const DEFAULT_STYLE_INDEX = 0;
+import { DEFAULT_VIEW_STATE, DEFAULT_STYLE_INDEX, STYLES } from "./constants";
 
 /**
  * URL クエリから数値パラメータを読み取り、不正値は null として扱う。

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,79 +2,9 @@ import { useCallback, useEffect, useState } from "react";
 import Map, { FullscreenControl, GeolocateControl, NavigationControl, ScaleControl } from "react-map-gl/maplibre";
 import "maplibre-gl/dist/maplibre-gl.css";
 import "./App.css";
-import type { MapView, InitialUrlState } from "./types";
-import { DEFAULT_VIEW_STATE, DEFAULT_STYLE_INDEX, STYLES } from "./constants";
-
-/**
- * URL クエリから数値パラメータを読み取り、不正値は null として扱う。
- */
-function parseNumericQueryParam(params: URLSearchParams, key: string) {
-  const rawValue = params.get(key);
-  if (rawValue === null) {
-    return null;
-  }
-  const parsedValue = Number(rawValue);
-  if (!Number.isFinite(parsedValue)) {
-    return null;
-  }
-  return parsedValue;
-}
-
-/**
- * URL から初期表示に使う地図状態を読み取り、不正な指定の有無も返す。
- */
-function parseInitialUrlState(): InitialUrlState {
-  const params = new URLSearchParams(window.location.search);
-  const latitude = parseNumericQueryParam(params, "lat");
-  const longitude = parseNumericQueryParam(params, "lng");
-  const zoom = parseNumericQueryParam(params, "zoom");
-  const styleKey = params.get("style");
-  const hasViewParams = params.has("lat") || params.has("lng") || params.has("zoom");
-  const hasCompleteViewParams = params.has("lat") && params.has("lng") && params.has("zoom");
-
-  let viewState = DEFAULT_VIEW_STATE;
-  let styleIndex = DEFAULT_STYLE_INDEX;
-  let shouldRewriteUrl = false;
-
-  if (hasViewParams) {
-    if (hasCompleteViewParams && latitude !== null && longitude !== null && zoom !== null) {
-      viewState = {
-        latitude,
-        longitude,
-        zoom,
-      };
-    } else {
-      shouldRewriteUrl = true;
-    }
-  }
-
-  if (styleKey !== null) {
-    const parsedStyleIndex = STYLES.findIndex((style) => style.key === styleKey.toLowerCase());
-    if (parsedStyleIndex === -1) {
-      shouldRewriteUrl = true;
-    } else {
-      styleIndex = parsedStyleIndex;
-    }
-  }
-
-  return {
-    viewState,
-    styleIndex,
-    shouldRewriteUrl,
-  };
-}
-
-/**
- * 現在の地図表示位置とスタイルを URL クエリへ反映する。
- */
-function updateUrlFromState(viewState: MapView, styleIndex: number) {
-  const url = new URL(window.location.href);
-  url.searchParams.set("lat", viewState.latitude.toFixed(6));
-  url.searchParams.set("lng", viewState.longitude.toFixed(6));
-  url.searchParams.set("zoom", viewState.zoom.toFixed(2));
-  url.searchParams.set("style", STYLES[styleIndex].key);
-  window.history.replaceState(null, "", url);
-}
+import type { InitialUrlState, MapView } from "./types";
+import { STYLES } from "./constants";
+import { parseInitialUrlState, updateUrlFromState } from "./urlState";
 
 /**
  * 地図本体とスタイル切替 UI を表示する。

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,10 +79,14 @@ function updateUrlFromViewState(viewState: MapView) {
   window.history.replaceState(null, "", url);
 }
 
+/**
+ * 地図本体とスタイル切替 UI を表示する。
+ */
 export function App() {
   const [selectedStyleIndex, setSelectedStyleIndex] = useState<number>(0);
   const [initialViewState] = useState<MapView>(() => parseViewStateFromUrl());
 
+  /** 選択中の地図スタイルを更新する */
   const handleStyleChange = useCallback((index: number) => {
     setSelectedStyleIndex(index);
   }, []);
@@ -109,6 +113,7 @@ export function App() {
  * 地図スタイルの切替ボタンを表示するコンポーネント
  */
 function StyleSwitcher(props: { styleIndex: number; handleStyleChange: (index: number) => void }) {
+  /** クリックされたスタイル番号を親コンポーネントへ通知する */
   const handleClick = useCallback(
     (index: number) => {
       props.handleStyleChange(index);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,27 @@
+import type { StyleSpecification } from "maplibre-gl";
+import * as darkStyleJson from "../public/dark/style.json";
+import * as lightStyleJson from "../public/light/style.json";
+import type { MapView } from "./types";
+
+/**
+ * 利用可能な地図スタイルの一覧。
+ *
+ * 各要素は以下のプロパティを持つ:
+ * - `key`: スタイルを一意に識別するキー
+ * - `name`: UIで表示するスタイル名
+ * - `json`: maplibre の `StyleSpecification` として扱うスタイル定義
+ */
+export const STYLES = [
+  { key: "dark", name: "Dark", json: darkStyleJson as unknown as StyleSpecification },
+  { key: "light", name: "Light", json: lightStyleJson as unknown as StyleSpecification },
+];
+
+/** デフォルトの地図表示状態（アプリ起動時の中心座標とズーム） */
+export const DEFAULT_VIEW_STATE: MapView = {
+  latitude: 36,
+  longitude: 138,
+  zoom: 7,
+};
+
+/** デフォルトで選択されるスタイルのインデックス（`STYLES` 配列のインデックス） */
+export const DEFAULT_STYLE_INDEX = 0;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,27 @@
+/**
+ * 地図ビューを表す型
+ *
+ * 中心座標（緯度・経度）とズームレベルをまとめて保持する
+ */
+export type MapView = {
+  /** 中心点の緯度（小数、度単位） */
+  latitude: number;
+  /** 中心点の経度（小数、度単位） */
+  longitude: number;
+  /** ズームレベル（数値） */
+  zoom: number;
+};
+
+/**
+ * 初期URLに含めるアプリケーション状態を表す型
+ *
+ * ページ読み込み時にURLへシリアライズして復元可能な情報をまとめる
+ */
+export type InitialUrlState = {
+  /** 表示する地図の状態（MapView） */
+  viewState: MapView;
+  /** 選択中のマップスタイルのインデックス */
+  styleIndex: number;
+  /** アプリ起動時にURLを書き換えるかどうかのフラグ */
+  shouldRewriteUrl: boolean;
+};

--- a/src/urlState.test.ts
+++ b/src/urlState.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { DEFAULT_STYLE_INDEX, DEFAULT_VIEW_STATE } from "./constants";
+import { parseInitialUrlState, parseNumericQueryParam, updateUrlFromState } from "./urlState";
+
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+
+type MockWindow = {
+  location: {
+    search: string;
+    href: string;
+  };
+  history: {
+    replaceState: ReturnType<typeof vi.fn>;
+  };
+};
+
+function setMockWindow(url: string): MockWindow {
+  const parsedUrl = new URL(url);
+  const mockWindow: MockWindow = {
+    location: {
+      search: parsedUrl.search,
+      href: parsedUrl.href,
+    },
+    history: {
+      replaceState: vi.fn(),
+    },
+  };
+
+  Object.defineProperty(globalThis, "window", {
+    value: mockWindow,
+    configurable: true,
+    writable: true,
+  });
+
+  return mockWindow;
+}
+
+afterEach(() => {
+  if (originalWindowDescriptor) {
+    Object.defineProperty(globalThis, "window", originalWindowDescriptor);
+    return;
+  }
+
+  Reflect.deleteProperty(globalThis, "window");
+});
+
+describe("parseNumericQueryParam()", () => {
+  test("キーが存在しないときは null を返す", () => {
+    const params = new URLSearchParams("lat=35");
+
+    expect(parseNumericQueryParam(params, "zoom")).toBeNull();
+  });
+
+  test("不正な数値が指定されたときは null を返す", () => {
+    const params = new URLSearchParams("zoom=abc");
+
+    expect(parseNumericQueryParam(params, "zoom")).toBeNull();
+  });
+
+  test("数値なら数値を返す", () => {
+    const params = new URLSearchParams("zoom=12.5");
+
+    expect(parseNumericQueryParam(params, "zoom")).toBe(12.5);
+  });
+});
+
+describe("parseInitialUrlState()", () => {
+  test("view と style が有効なとき、URLから状態を復元する", () => {
+    setMockWindow("https://example.com/map-style?lat=35.6812&lng=139.7671&zoom=14.25&style=LIGHT");
+
+    expect(parseInitialUrlState()).toEqual({
+      viewState: {
+        latitude: 35.6812,
+        longitude: 139.7671,
+        zoom: 14.25,
+      },
+      styleIndex: 1,
+      shouldRewriteUrl: false,
+    });
+  });
+
+  test("view パラメータが不完全なとき、デフォルト値を使い URL 書き換えフラグを立てる", () => {
+    setMockWindow("https://example.com/map-style?lat=35.6812");
+
+    expect(parseInitialUrlState()).toEqual({
+      viewState: DEFAULT_VIEW_STATE,
+      styleIndex: DEFAULT_STYLE_INDEX,
+      shouldRewriteUrl: true,
+    });
+  });
+
+  test("style が不正なとき、style はデフォルトにして URL 書き換えフラグを立てる", () => {
+    setMockWindow("https://example.com/map-style?style=unknown");
+
+    expect(parseInitialUrlState()).toEqual({
+      viewState: DEFAULT_VIEW_STATE,
+      styleIndex: DEFAULT_STYLE_INDEX,
+      shouldRewriteUrl: true,
+    });
+  });
+});
+
+describe("updateUrlFromState()", () => {
+  test("地図状態とスタイルをクエリに反映する", () => {
+    const mockWindow = setMockWindow("https://example.com/map-style");
+
+    updateUrlFromState({ latitude: 35.6812367, longitude: 139.7671248, zoom: 14.235 }, 1);
+
+    expect(mockWindow.history.replaceState).toHaveBeenCalledTimes(1);
+    const replaceStateArgs = mockWindow.history.replaceState.mock.calls[0];
+    const replacedUrl = replaceStateArgs[2] as URL;
+
+    expect(replaceStateArgs[0]).toBeNull();
+    expect(replaceStateArgs[1]).toBe("");
+    expect(replacedUrl.searchParams.get("lat")).toBe("35.681237");
+    expect(replacedUrl.searchParams.get("lng")).toBe("139.767125");
+    expect(replacedUrl.searchParams.get("zoom")).toBe("14.23");
+    expect(replacedUrl.searchParams.get("style")).toBe("light");
+  });
+});

--- a/src/urlState.ts
+++ b/src/urlState.ts
@@ -1,0 +1,73 @@
+import type { InitialUrlState, MapView } from "./types";
+import { DEFAULT_STYLE_INDEX, DEFAULT_VIEW_STATE, STYLES } from "./constants";
+
+/**
+ * URL クエリから数値パラメータを読み取り、不正値は null として扱う。
+ */
+export function parseNumericQueryParam(params: URLSearchParams, key: string) {
+  const rawValue = params.get(key);
+  if (rawValue === null) {
+    return null;
+  }
+  const parsedValue = Number(rawValue);
+  if (!Number.isFinite(parsedValue)) {
+    return null;
+  }
+  return parsedValue;
+}
+
+/**
+ * URL から初期表示に使う地図状態を読み取り、不正な指定の有無も返す。
+ */
+export function parseInitialUrlState(): InitialUrlState {
+  const params = new URLSearchParams(window.location.search);
+  const latitude = parseNumericQueryParam(params, "lat");
+  const longitude = parseNumericQueryParam(params, "lng");
+  const zoom = parseNumericQueryParam(params, "zoom");
+  const styleKey = params.get("style");
+  const hasViewParams = params.has("lat") || params.has("lng") || params.has("zoom");
+  const hasCompleteViewParams = params.has("lat") && params.has("lng") && params.has("zoom");
+
+  let viewState = DEFAULT_VIEW_STATE;
+  let styleIndex = DEFAULT_STYLE_INDEX;
+  let shouldRewriteUrl = false;
+
+  if (hasViewParams) {
+    if (hasCompleteViewParams && latitude !== null && longitude !== null && zoom !== null) {
+      viewState = {
+        latitude,
+        longitude,
+        zoom,
+      };
+    } else {
+      shouldRewriteUrl = true;
+    }
+  }
+
+  if (styleKey !== null) {
+    const parsedStyleIndex = STYLES.findIndex((style) => style.key === styleKey.toLowerCase());
+    if (parsedStyleIndex === -1) {
+      shouldRewriteUrl = true;
+    } else {
+      styleIndex = parsedStyleIndex;
+    }
+  }
+
+  return {
+    viewState,
+    styleIndex,
+    shouldRewriteUrl,
+  };
+}
+
+/**
+ * 現在の地図表示位置とスタイルを URL クエリへ反映する。
+ */
+export function updateUrlFromState(viewState: MapView, styleIndex: number) {
+  const url = new URL(window.location.href);
+  url.searchParams.set("lat", viewState.latitude.toFixed(6));
+  url.searchParams.set("lng", viewState.longitude.toFixed(6));
+  url.searchParams.set("zoom", viewState.zoom.toFixed(2));
+  url.searchParams.set("style", STYLES[styleIndex].key);
+  window.history.replaceState(null, "", url);
+}


### PR DESCRIPTION
## 概要

座標・ズームレベル・地図スタイルを URL のパラメーターで指定可能にする。

## やったこと

- パラメーターが指定されたときに、当該パラメーターを元に地図を表示する機能を実装。
- 地図の移動・拡大縮小・スタイル変換を行ったときに、URL のパラメーターへ反映する機能を実装。
- 関連するテストの追加。
- 定数の定義箇所変更等のリファクタリング。

## やらないこと / 今後やること

-

## 関連チケット

-
