### PR TITLE
GitHub Actions のセキュリティ向上

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,8 @@ on:
     branches:
       - main # main ブランチに push されたときに実行される
 
-permissions: {}
+permissions:
+  contents: write # GitHub Pages にデプロイするために必要
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main # main ブランチに push されたときに実行される
+  workflow_dispatch: # 手動実行を許可
 
 permissions:
   contents: write # GitHub Pages にデプロイするために必要

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main # main ブランチに push されたときに実行される
 
+permissions: {}
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -13,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,15 +12,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
         with:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: "24"
           cache: "pnpm"
@@ -32,7 +32,7 @@ jobs:
         run: pnpm run build
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,13 +6,14 @@ on:
       - main # main ブランチに push されたときに実行される
   workflow_dispatch: # 手動実行を許可
 
-permissions:
-  contents: write # GitHub Pages にデプロイするために必要
+permissions: {}
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: write # GitHub Pages にデプロイするために必要
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,8 @@ on:
   push:
     branches:
       - main # main ブランチに push されたときに実行される
-  workflow_dispatch: # 手動実行を許可
+  pull_request:
+    branches: [main] # main への PR が作成・更新された時に実行
 
 permissions: {}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - main # main ブランチに push されたときに実行される
-  pull_request:
-    branches: [main] # main への PR が作成・更新された時に実行
+  # pull_request:
+  #   branches: [main] # main への PR が作成・更新された時に実行 (動作確認用なので、通常時は OFF にしておく)
 
 permissions: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,3 @@
-ignoredBuiltDependencies:
-  - esbuild
+allowBuilds:
+  esbuild: true
 minimumReleaseAge: 2880


### PR DESCRIPTION
## 概要

ビルドと GitHub Pages へのデプロイを行うワークフローのセキュリティを強化する。

## やったこと

基本的には `pinact run -u` で更新・バージョン固定を行うとともに、`ghasec` でエラーが出ないように変更した。

- 使用する Actions のバージョンアップ
- 使用する Actions をバージョン指定から SHA 指定へ変更
- 最小限の適切な権限を指定
- タイムアウト時間の設定（これのみセキュリティ関係ではない）

## やらないこと / 今後やること

-

## 関連チケット

-
